### PR TITLE
Add OSD rotation

### DIFF
--- a/css/mirador.css
+++ b/css/mirador.css
@@ -1119,41 +1119,53 @@ li.highlight {
   right:0;
   margin:1%;
 }
+.mirador-osd-positive-rotate {
+  font-size:130%;
+  position:absolute;
+  right:0px;
+  top:5px;
+}
+.mirador-osd-negative-rotate {
+  font-size:130%;
+  position:absolute;
+  right:0px;
+  top:30px;
+}
 .mirador-osd-up {
   position:absolute;
-  right:20px;
-  top:0;
+  right:51px;
+  top:0px;
 }
 .mirador-osd-right {
   position:absolute;
-  right:0;
+  right:31px;
   top:20px;
 }
 .mirador-osd-down {
   position:absolute;
-  right:20px;
+  right:51px;
   top:40px;
 }
 .mirador-osd-left {
   position:absolute;
-  right:40px;
+  right:71px;
   top:20px;
 }
 .mirador-osd-zoom-in {
   font-size:130%;
   position:absolute;
-  right:70px;
+  right:100px;
   top:5px;
 }
 .mirador-osd-zoom-out {
   font-size:130%;
   position:absolute;
-  right:70px;
+  right:100px;
   top:30px;
 }
 .mirador-osd-go-home {
   position: absolute;
-  right:20px;
+  right:51px;
   top:20px;
 }
 .mirador-osd-context-controls {

--- a/js/src/widgets/bookView.js
+++ b/js/src/widgets/bookView.js
@@ -174,6 +174,27 @@ bindEvents: function() {
         }
       });
 
+      this.element.find('.mirador-osd-positive-rotate').on('click', function() {
+        var osd = _this.osd;
+        if ( osd.viewport ) {
+        var currentRotation = parseInt(osd.viewport.getRotation());
+            osd.viewport.setRotation(
+            currentRotation + 90
+          );
+          osd.viewport.applyConstraints();
+        }
+      });
+      this.element.find('.mirador-osd-negative-rotate').on('click', function() {
+        var osd = _this.osd;
+        if ( osd.viewport ) {
+          var currentRotation = parseInt(osd.viewport.getRotation());
+            osd.viewport.setRotation(
+            currentRotation - 90
+          );
+          osd.viewport.applyConstraints();
+        }
+      });
+
       this.element.find('.mirador-osd-toggle-bottom-panel').on('click', function() {
         _this.eventEmitter.publish('TOGGLE_BOTTOM_PANEL_VISIBILITY.' + _this.windowId);
       });

--- a/js/src/widgets/hud.js
+++ b/js/src/widgets/hud.js
@@ -184,6 +184,12 @@
                                  '<a class="mirador-osd-go-home hud-control" role="button" aria-label="Reset image bounds">',
                                  '<i class="fa fa-home"></i>',
                                  '</a>',
+                                 '<a title="Rotate +90 degrees" class="mirador-osd-positive-rotate hud-control">',
+                                 '<i class="fa fa-rotate-right"></i>',
+                                 '</a>',
+                                 '<a title="Rotate -90 degrees" class="mirador-osd-negative-rotate hud-control">',
+                                 '<i class="fa fa-rotate-left"></i>',
+                                 '</a>',
                                  '</div>'
     ].join(''))
 

--- a/js/src/widgets/imageView.js
+++ b/js/src/widgets/imageView.js
@@ -242,6 +242,27 @@
         }
       });
 
+      this.element.find('.mirador-osd-positive-rotate').on('click', function() {
+        var osd = _this.osd;
+        if ( osd.viewport ) {
+        var currentRotation = parseInt(osd.viewport.getRotation());
+            osd.viewport.setRotation(
+            currentRotation + 90
+          );
+          osd.viewport.applyConstraints();
+        }
+      });
+      this.element.find('.mirador-osd-negative-rotate').on('click', function() {
+        var osd = _this.osd;
+        if ( osd.viewport ) {
+          var currentRotation = parseInt(osd.viewport.getRotation());
+            osd.viewport.setRotation(
+            currentRotation - 90
+          );
+          osd.viewport.applyConstraints();
+        }
+      });
+
       this.element.find('.mirador-osd-toggle-bottom-panel').on('click', function() {
         _this.eventEmitter.publish('TOGGLE_BOTTOM_PANEL_VISIBILITY.' + _this.windowId);
       });


### PR DESCRIPTION
Still an open question to remove the titles (text hints from the rotation links) on the rotate icons _or_ to add them to the other OSD icons. I think it's useful to have text hints, but I guess there might be a reason Mirador isn't using them?
